### PR TITLE
feat: Allow player to select deployment slot

### DIFF
--- a/app.py
+++ b/app.py
@@ -282,13 +282,13 @@ def buy_unit(unit_id):
 @app.route('/deploy_unit/<unit_id>', methods=['POST'])
 def deploy_unit(unit_id):
     unit_to_deploy = next((u for u in game.player1.barracks if u.id == unit_id), None)
-    if unit_to_deploy and not any(u.id == unit_id for u in game.player1.units):
-        slot = next((pos for pos, unit in game.player1.board.items() if unit is None), None)
-        if slot:
-            deployed_unit = Unit.from_dict(unit_to_deploy.to_dict())
-            deployed_unit.from_barracks = True
-            game.player1.units.append(deployed_unit)
-            game.player1.board[slot] = deployed_unit
+    slot = request.form.get('slot')
+    if unit_to_deploy and not any(u.id == unit_id for u in game.player1.units) and slot and slot in game.player1.board and game.player1.board[slot] is None:
+        deployed_unit = Unit.from_dict(unit_to_deploy.to_dict())
+        deployed_unit.from_barracks = True
+        deployed_unit.position = slot
+        game.player1.units.append(deployed_unit)
+        game.player1.board[slot] = deployed_unit
     return redirect(url_for('index'))
 
 @app.route('/return_to_barracks/<unit_id>', methods=['POST'])

--- a/templates/_macros.html
+++ b/templates/_macros.html
@@ -38,7 +38,28 @@
             </form>
         {% elif action == 'deploy' %}
             <form action="/deploy_unit/{{ unit.id }}" method="post">
-                <button type="submit">Einsetzen</button>
+                {% set ns = namespace(has_empty_slot=false) %}
+                {% for pos, u in game.player1.board.items() %}
+                    {% if u is none %}
+                        {% set ns.has_empty_slot = true %}
+                    {% endif %}
+                {% endfor %}
+
+                {% if ns.has_empty_slot %}
+                    <div class="deploy-options" style="padding: 5px 0;">
+                        {% for pos, u in game.player1.board.items() %}
+                            {% if u is none %}
+                                <label style="display: block; text-align: left; margin: 2px 10px; font-size: 0.9em;">
+                                    <input type="radio" name="slot" value="{{ pos }}" required> Pos: {{ pos.replace(',', ' | ') }}
+                                </label>
+                            {% endif %}
+                        {% endfor %}
+                    </div>
+                    <button type="submit">Einsetzen</button>
+                {% else %}
+                    <p style="font-size: 0.9em; color: #aaa;">Board ist voll.</p>
+                    <button type="submit" disabled>Einsetzen</button>
+                {% endif %}
             </form>
         {% elif action == 'upgrade' %}
             <div class="xp">XP: {{ unit.xp }} / {{ unit.level * 100 }}</div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -185,7 +185,7 @@
             <h3>Kaserne</h3>
             {% if game.player1.barracks %}
                 {% for unit in game.player1.barracks %}
-                    {{ render_unit_card(unit, class_icons, action='deploy') }}
+                    {{ render_unit_card(unit, class_icons, action='deploy', game=game) }}
                 {% endfor %}
             {% else %}
                 <p>Leer</p>


### PR DESCRIPTION
This feature enhances the unit deployment mechanic by allowing players to choose a specific empty slot on the board for their barracks units.

- Modified `_macros.html` to replace the simple 'Deploy' button with a form containing radio buttons for each available board position.
- Updated the `deploy_unit` function in `app.py` to process the selected slot from the form data and place the unit accordingly.
- Passed the `game` object to the rendering macro in `index.html` to enable access to the board state.