### PR TITLE
feat: Overhaul barracks, level-up mechanics, and XP display

### DIFF
--- a/app.py
+++ b/app.py
@@ -303,14 +303,18 @@ def deploy_unit(unit_id):
 def return_to_barracks(unit_id):
     unit_to_return = next((u for u in game.player1.units if u.id == unit_id), None)
     if unit_to_return:
-        game.player1.units.remove(unit_to_return)
+        # Remove the unit from the active team list.
+        game.player1.units = [u for u in game.player1.units if u.id != unit_id]
+        # Remove the unit from the board positions.
         for pos, unit in game.player1.board.items():
             if unit and unit.id == unit_id:
                 game.player1.board[pos] = None
                 break
+        # Add the unit to the barracks if it's not already there.
         if not any(u.id == unit_id for u in game.player1.barracks):
             game.player1.barracks.append(unit_to_return)
-            save_data(game.player1)
+        # Save the updated player data.
+        save_data(game.player1)
     return redirect(url_for('index'))
 
 @app.route('/start_combat', methods=['POST'])

--- a/templates/_macros.html
+++ b/templates/_macros.html
@@ -37,6 +37,7 @@
                 <button type="submit" {% if player_gold is not none and player_gold < unit.cost %}disabled{% endif %}>Kaufen</button>
             </form>
         {% elif action == 'deploy' %}
+            <div class="xp">XP: {{ unit.xp }} / {{ unit.level * 100 }}</div>
             <form action="/deploy_unit/{{ unit.id }}" method="post">
                 {% set ns = namespace(has_empty_slot=false) %}
                 {% for pos, u in game.player1.board.items() %}
@@ -69,6 +70,7 @@
             </form>
             {% endif %}
         {% elif action == 'board' %}
+            <div class="xp">XP: {{ unit.xp }} / {{ unit.level * 100 }}</div>
             {% if unit.from_barracks %}
                 <form action="{{ url_for('return_to_barracks', unit_id=unit.id) }}" method="post" style="margin-top: 5px;">
                     <button type="submit" class="return-button" style="font-size: 0.8em; padding: 0.3em 0.5em; background-color: #6c757d;">Zurück</button>


### PR DESCRIPTION
This commit introduces several major changes to the barracks and unit progression systems based on user feedback, including bug fixes identified during development.

- **Barracks-Only Level-Up**: Units now only gain experience points after combat. The actual level-up process, including stat increases, must be manually triggered from the barracks screen via a new 'Level Up!' button.
- **Persistent Barracks**: Deploying a unit from the barracks to the game board now removes it from the barracks, making the decision more strategic.
- **Return to Barracks Fix**: The 'Return to Barracks' functionality has been corrected to properly add the unit back to the barracks list and remove it from the active team, preventing unit duplication.
- **XP Display**: The unit card macro has been updated to display the unit's current XP during the preparation phase, both for units in the barracks and on the board.
- **Level-Up Logic Refactor**: The `Unit` class has been refactored to separate XP gain (`add_xp`) from the level-up process (`level_up_if_possible`).
- **New Endpoint**: A new `/level_up_unit/<unit_id>` endpoint has been added to handle the level-up requests from the barracks.