### PR TITLE
feat: Add background images to main menu and barracks

### DIFF
--- a/flask_app.log
+++ b/flask_app.log
@@ -1,0 +1,2 @@
+ * Serving Flask app 'app'
+ * Debug mode: on

--- a/templates/barracks.html
+++ b/templates/barracks.html
@@ -8,6 +8,11 @@
         body {
             font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
             padding: 2em;
+            background-image: url('/static/Kaserne.png');
+            background-size: cover;
+            background-position: center;
+            background-repeat: no-repeat;
+            background-attachment: fixed;
             background-color: #1a1a1a;
             color: #e0e0e0;
         }

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,6 +10,11 @@
             text-align: center;
             margin: 0;
             padding: 1em;
+            background-image: url('/static/Background_01.png');
+            background-size: cover;
+            background-position: center;
+            background-repeat: no-repeat;
+            background-attachment: fixed;
             background-color: #1a1a1a;
             color: #e0e0e0;
         }


### PR DESCRIPTION
- Rename `assets` folder to `static` to follow Flask conventions.
- Add `Background.png`, `Background_01.png`, `Kaserne.png`, and `Logo.png` to the `static` folder.
- Set `Background_01.png` as the background for the main menu (`index.html`).
- Set `Kaserne.png` as the background for the barracks (`barracks.html`).